### PR TITLE
Export the StealPush type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,18 @@ var getManifest = memoize(function(pth){
 	return JSON.parse(data);
 });
 
-function create({manifest: manifestPath, cwd = process.cwd()}) {
-	return function(moduleIdentifier){
-		var manifest = getManifest(manifestPath);
-		var assets = normalize(moduleIdentifier, manifest);
+class StealPush {
+	constructor(options = {}) {
+		this.manifestPath = options.manifest;
+		this.serverRoot = options.serverRoot || "/";
+		this.root = options.root || process.cwd();
+	}
+
+	for(moduleIdentifier){
+		const manifest = getManifest(this.manifestPath);
+		const serverRoot = this.serverRoot;
+		const root = this.root;
+		let assets = normalize(moduleIdentifier, manifest);
 
 		if(!assets) {
 			throw new Error(`${moduleIdentifier} is not in the manifest file.`);
@@ -25,7 +33,7 @@ function create({manifest: manifestPath, cwd = process.cwd()}) {
 		return function(req, res, next = noop){
 			if(typeof res.push !== "function") {
 				for(let [pth, asset] of assets) {
-					let serverPath = `/${pth}`;
+					let serverPath = path.join(serverRoot, pth);
 					let header;
 
 					switch(asset.type) {
@@ -44,9 +52,9 @@ function create({manifest: manifestPath, cwd = process.cwd()}) {
 			} else {
 				for(let [pth, asset] of assets) {
 					let readStream = fs.createReadStream(
-						path.join(cwd, pth)
+						path.join(root, pth)
 					);
-					let serverPath = `/${pth}`;
+					let serverPath = path.join(serverRoot, pth);
 
 					switch(asset.type) {
 						case "script":
@@ -61,11 +69,18 @@ function create({manifest: manifestPath, cwd = process.cwd()}) {
 					}
 				}
 			}
-
-			next();
 		};
-	};
+	}
 }
+
+function create(options) {
+	var stealPush = new StealPush(options);
+
+	return function(moduleIdentifier){
+		return stealPush.for(moduleIdentifier);
+	}
+}
+
 
 function makeIterable(obj) {
 	var keys = Object.keys(obj);
@@ -121,8 +136,9 @@ function pushStyle(req, res, inputStream, pth){
 }
 
 // Set it up with the defaults
-exports = module.exports = create({
-	manifest: "dist/bundles"
+exports = module.exports = new StealPush({
+	manifest: "dist/bundles.json"
 });
 
+exports.StealPush = StealPush;
 exports.create = create;

--- a/readme.md
+++ b/readme.md
@@ -91,17 +91,29 @@ app.get("/order/details",
 server.listen(8080);
 ```
 
-### Specifying manifest file
+### StealPush constructor
 
-By default steal-push assumes your manifest file is located at `$(pwd)/dist/bundles.json`. If you have moved this manifest file to a different location you can create a new `stealPush` from that root:
+The `StealPush` constructor can be used to configure things such as the server root, and the location of the manifest file. Typical usage looks like:
 
 ```js
-var stealPush = require("steal-push").create({
-	manifest: __dirname + "/path/to/bundles.json"
+const StealPush = require("steal-push").StealPush;
+
+const stealPush = new StealPush({
+	manifest: "dist/bundles.json",
+	root: __dirname + "/assets",
+	serverRoot: "/app"
 });
 
-var push = stealPush("main"); // ...
+app.get("/",
+	stealPush.for("main"),
+	function(req, res){
+		...
+	});
 ```
+
+#### StealPush#for
+
+The `for()` method on the StealPush object is used to create a function that takes a request and response object.
 
 ## License
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,21 @@
 require("./test_push");
 require("./test_preload");
+
+const assert = require("assert");
+const stealPush = require("../lib/index.js");
+
+describe("StealPush", function(){
+	const StealPush = stealPush.StealPush;
+
+	describe("constructor", function(){
+		it("is exported", function(){
+			assert.ok(StealPush, "constructor is exported");
+		});
+	});
+});
+
+describe(".create", function(){
+	it("exists", function(){
+		assert.equal(typeof stealPush.create, "function");
+	});
+});

--- a/test/test_preload.js
+++ b/test/test_preload.js
@@ -7,7 +7,7 @@ const Writable = require("stream").Writable;
 describe("Preload", function(){
 	var stealPush = sp.create({
 		manifest: __dirname + "/tests/basics/bundles.json",
-		cwd: __dirname + "/tests/basics"
+		root: __dirname + "/tests/basics"
 	});
 
 	var push = stealPush("index");

--- a/test/test_push.js
+++ b/test/test_push.js
@@ -1,16 +1,16 @@
 const assert = require("assert");
 const merge = require("merge-stream");
 const through = require("through2");
-const sp = require("../lib/index.js");
+const StealPush = require("../lib/index.js").StealPush;
 const Writable = require("stream").Writable;
 
 describe("PUSH", function(){
-	var stealPush = sp.create({
+	var stealPush = new StealPush({
 		manifest: __dirname + "/tests/basics/bundles.json",
-		cwd: __dirname + "/tests/basics"
+		root: __dirname + "/tests/basics"
 	});
 
-	var push = stealPush("index");
+	var push = stealPush.for("index");
 
 	it("works", function(){
 		var req = through(() => {});
@@ -25,6 +25,8 @@ describe("PUSH", function(){
 			pushes.push(p);
 			return p;
 		};
+
+		debugger;
 
 		push(req, res);
 


### PR DESCRIPTION
The StealPush type is a constructor that creates an instance containing
configuration included. Using `StealPush.prototype.for` will create
functions that take request and response object for a given root
moduleIdentifier.

Closes #8 and #9