### PR TITLE
Make multiple Link headers be added to responses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,23 +31,30 @@ class StealPush {
 		assets = makeIterable(assets);
 
 		return function(req, res, next = noop){
-			if(typeof res.push !== "function") {
+			if(!isHTTP2(res)) {
+				let headers = [];
+
 				for(let [pth, asset] of assets) {
 					let serverPath = path.join(serverRoot, pth);
-					let header;
 
 					switch(asset.type) {
 						case "script":
-							header = `<${serverPath}>; rel=preload; as=script;`;
+							headers.push(
+								`<${serverPath}>; rel=preload; as=script;`
+							);
 							break;
 						case "style":
-							header = `<${serverPath}>; rel=preload; as=style;`;
+							headers.push(
+								`<${serverPath}>; rel=preload; as=style;`
+							);
 							break;
 						default:
 							return next();
 					}
+				}
 
-					res.setHeader("Link", header);
+				if(headers.length) {
+					res.setHeader("Link", headers);
 				}
 			} else {
 				for(let [pth, asset] of assets) {
@@ -81,6 +88,9 @@ function create(options) {
 	}
 }
 
+function isHTTP2(response) {
+	return typeof response.push === "function";
+}
 
 function makeIterable(obj) {
 	var keys = Object.keys(obj);

--- a/test/test_preload.js
+++ b/test/test_preload.js
@@ -15,17 +15,19 @@ describe("Preload", function(){
 	it("works", function(){
 		var req = through(() => {});
 		req.headers = {
-			"accept-encoding": "gzip, deflate, br"	
+			"accept-encoding": "gzip, deflate, br"
 		};
 		var res = through(() => {});
 		res.push = undefined;
 
-		var pushes = [];
+		var headers = {}
 		res.setHeader = (name, val) => {
-			pushes.push(val);
+			headers[name.toLowerCase()] = val;
 		};
 
 		push(req, res);
+
+		var pushes = headers.link;
 		assert.equal(pushes.length, 2, "There are preloads for style and script");
 	});
 });


### PR DESCRIPTION
This fixes #11. Now multiple `Link` headers are added to the responses.